### PR TITLE
Added Property and Direction to URL to prevent 400 Bad Request

### DIFF
--- a/humbletrove/HumbleTrove.py
+++ b/humbletrove/HumbleTrove.py
@@ -27,7 +27,7 @@ class HumbleTrove(object):
         print('Fetching Humble Trove product information...')
 
         while True:
-            chunk = requests.get('https://humblebundle.com/api/v1/trove/chunk?index={0}'.format(index)).json()
+            chunk = requests.get('https://humblebundle.com/api/v1/trove/chunk?property=popularity&direction=desc&index={0}'.format(index)).json()
 
             if not chunk:
                 break


### PR DESCRIPTION
With the previous Connection String the HumbleBundle API would always return "400 Bad Request" because these parameters where missing. This PR aims to prevent the error by adding Property and Direction to the connection String.

`https://humblebundle.com/api/v1/trove/chunk?property=popularity&direction=desc&index={0}`

This was tested on Windows 10 and should work on MacOS & Linux aswell.